### PR TITLE
Environment Updates

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 API_URL=http://192.168.1.201:8000
-S3_URL=http://192.168.1.201:4572/memory-content
+S3_URL=http://192.168.1.201:4566/memory-content
 PRIVACY_POLICY_URL=https://two.date/privacy.html

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -320,14 +320,14 @@ PODS:
     - React
   - RNCAsyncStorage (1.12.1):
     - React-Core
-  - RNCClipboard (1.5.0):
+  - RNCClipboard (1.5.1):
     - React-Core
   - RNCMaskedView (0.1.10):
     - React
-  - RNDateTimePicker (3.0.3):
+  - RNDateTimePicker (3.0.4):
     - React-Core
-  - RNFastImage (8.3.2):
-    - React
+  - RNFastImage (8.3.3):
+    - React-Core
     - SDWebImage (~> 5.8)
     - SDWebImageWebPCoder (~> 0.6.1)
   - RNGestureHandler (1.8.0):
@@ -345,8 +345,8 @@ PODS:
     - React-Core
   - RNReanimated (1.13.1):
     - React
-  - RNScreens (2.11.0):
-    - React
+  - RNScreens (2.14.0):
+    - React-Core
   - RNVectorIcons (7.1.0):
     - React
   - SDWebImage (5.9.2):
@@ -570,15 +570,15 @@ SPEC CHECKSUMS:
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
   ReactNativeART: 78edc68dd4a1e675338cd0cd113319cf3a65f2ab
   RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
-  RNCClipboard: c7abea1baea58adca5c1f29e56dd5261837b4892
+  RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
-  RNDateTimePicker: 6f62fd42ac8b58bcc30c43ac3620e5097e8a227f
-  RNFastImage: e19ba191922e7dab9d932a4d59d62d76660aa222
+  RNDateTimePicker: 3d1931e387248cb8f1d1d33740d4a1a82dfe622a
+  RNFastImage: ff7e055d085abe465b358ce5aa51e3c6d64b1efd
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNImageCropPicker: 16951bc02411f50c4d197488ed6406a23dc3b5f1
   RNReactNativeHapticFeedback: 653a8c126a0f5e88ce15ffe280b3ff37e1fbb285
   RNReanimated: dd8c286ab5dd4ba36d3a7fef8bff7e08711b5476
-  RNScreens: 0e91da98ab26d5d04c7b59a9b6bd694124caf88c
+  RNScreens: 2e278a90eb15092ed261d4f2271e3fc9b60d08d4
   RNVectorIcons: bc69e6a278b14842063605de32bec61f0b251a59
   SDWebImage: 0b42b8719ab0c5257177d5894306e8a336b21cbb
   SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21


### PR DESCRIPTION
## Description
`localstack` has updated the main port used to service traffic to `s3`. In addition to this change, the lock file for cocoapods has been updated.

## Testing
Manually

## Issue Resolution
N/A

## Dependencies
N/A