### PR TITLE
Set Timeout for PR Install

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - run: yarn install
+      - run: yarn install --network-timeout 100000
       - run: yarn test
   build:
     name: build


### PR DESCRIPTION
## Description
- Increase the timeout for yarn installation, as it seems to frequently fail on PRs

## Testing
- CI

## Issue Resolution
- N/A

## Dependencies
- N/A

## Screenshots
- N/A