### PR TITLE
Generate UID as part of Accept Terms

### DIFF
--- a/__tests__/authentication/RegisterScreen-test.tsx
+++ b/__tests__/authentication/RegisterScreen-test.tsx
@@ -99,7 +99,6 @@ describe('RegisterScreen', () => {
             firstName: 'Paul',
             lastName: 'Atreides',
             password: 'P?4Ot2ONz:IJO&%U',
-            uid: expect.any(String),
           },
         },
       );

--- a/__tests__/authentication/register_workflow/AcceptTermsScreen-test.tsx
+++ b/__tests__/authentication/register_workflow/AcceptTermsScreen-test.tsx
@@ -59,7 +59,7 @@ describe('AcceptTermsScreen', () => {
 
     test('it should make a register user request', () => {
       expect(AuthenticationService.registerUser).toHaveBeenCalledWith({
-        uid: tb.userRegistration.uid,
+        uid: expect.any(String),
         firstName: 'Gerry',
         lastName: 'Fletcher',
         email: 'admin@two.com',
@@ -112,7 +112,6 @@ class AcceptTermsScreenTestBed {
   // models
 
   userRegistration: UserRegistration = {
-    uid: uuidv4(),
     firstName: 'Gerry',
     lastName: 'Fletcher',
     email: 'admin@two.com',

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -509,7 +509,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 987ca4745097d45b1cf7ec2dec6e1a0e458f1ee1
+  FBReactNativeSpec: 8573b4dda80745521f877939607cfb1c349dd85b
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
@@ -558,4 +558,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 2a606e7c8ced91dd45e8798fa72dfa56357c2601
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/ios/two.xcodeproj/project.pbxproj
+++ b/ios/two.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "twoTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/two.app/two";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Two.app/Two";
 			};
 			name = Debug;
 		};
@@ -668,7 +668,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "date.two AppStore";
 				SWIFT_OBJC_BRIDGING_HEADER = "twoTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/two.app/two";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Two.app/Two";
 			};
 			name = Release;
 		};
@@ -761,7 +761,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -815,7 +815,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/src/authentication/AuthenticationService.tsx
+++ b/src/authentication/AuthenticationService.tsx
@@ -28,7 +28,9 @@ const login = (loginCredentials: LoginCredentials): Promise<MixedUser> =>
     persistTokens(r.data),
   );
 
-const registerUser = (userRegistration: UserRegistration): Promise<MixedUser> =>
+const registerUser = (
+  userRegistration: UserRegistration & {uid: string},
+): Promise<MixedUser> =>
   Gateway.post<Tokens>('/self', userRegistration).then(r =>
     persistTokens(r.data),
   );

--- a/src/authentication/register_workflow/AcceptTermsScreen.tsx
+++ b/src/authentication/register_workflow/AcceptTermsScreen.tsx
@@ -37,6 +37,7 @@ export const AcceptTermsScreen = () => {
     );
 
   const onSubmit = () => {
+    setLoading(true);
     AuthenticationService.registerUser({...reg, uid})
       .then(() => navigateToConnectCodeScreen())
       .catch((e: ErrorResponse) => setError(e.reason))

--- a/src/authentication/register_workflow/AcceptTermsScreen.tsx
+++ b/src/authentication/register_workflow/AcceptTermsScreen.tsx
@@ -13,10 +13,12 @@ import type {ErrorResponse} from '../../http/Response';
 import type {UserRegistration} from './UserRegistrationModel';
 import {AcceptSwitch} from './AcceptSwitch';
 import {Route, Routes} from '../../navigation/RootNavigation';
+import uuidv4 from 'uuidv4';
 
 export const AcceptTermsScreen = () => {
   const route = useRoute<Route<'AcceptTermsScreen'>>();
   const navigation = useNavigation<Routes>();
+  const uid = uuidv4();
 
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
@@ -35,7 +37,7 @@ export const AcceptTermsScreen = () => {
     );
 
   const onSubmit = () => {
-    AuthenticationService.registerUser(reg)
+    AuthenticationService.registerUser({...reg, uid})
       .then(() => navigateToConnectCodeScreen())
       .catch((e: ErrorResponse) => setError(e.reason))
       .finally(() => setLoading(false));

--- a/src/authentication/register_workflow/UserRegistrationModel.tsx
+++ b/src/authentication/register_workflow/UserRegistrationModel.tsx
@@ -1,10 +1,8 @@
 import 'react-native-get-random-values';
-import uuid from 'uuidv4';
 
 import EmailValidator from '../../forms/EmailValidator';
 
 class UserRegistration {
-  uid = uuid();
   firstName = '';
   lastName = '';
   email = '';


### PR DESCRIPTION
## Description
- Instead of generating the uid as part of the register page, it should be generated on the accept terms. That way if a user navigates away and back, a new uid will be generated
