### PR TITLE
Fix Image and Video Compression

### DIFF
--- a/src/content/ContentPicker.ts
+++ b/src/content/ContentPicker.ts
@@ -21,6 +21,7 @@ const selectContent = async (): Promise<Image[]> => {
   return ImagePicker.openPicker({
     multiple: true,
     maxFiles: 15,
+    compressVideoPreset: 'HighestQuality',
   })
     .then(content => (Array.isArray(content) ? content : [content]))
     .catch(({message}: Error) => {

--- a/src/content/ContentService.ts
+++ b/src/content/ContentService.ts
@@ -26,7 +26,7 @@ export const uploadContent = (
   const form = new FormData();
 
   form.append('thumbnail', {
-    name: 'thumbnail.png',
+    name: 'thumbnail',
     type: thumbnail.mime,
     uri: thumbnail.path,
   });

--- a/src/content/compression/ImageCompression.ts
+++ b/src/content/compression/ImageCompression.ts
@@ -30,23 +30,23 @@ export const compressImage = async (
 };
 
 const thumbnail = async (input: string): Promise<File> => {
-  const output = RNFS.TemporaryDirectoryPath + uuid() + '.png';
-  const sized = await resize(input, output, 100, 100, 'cover');
+  const output = RNFS.TemporaryDirectoryPath + uuid() + '.jpeg';
+  const sized = await resize(input, output, 1280, 720, 'cover');
   console.log(`Thumbnail ${sized.width}x${sized.height} - ${sized.size} bytes`);
   return sized;
 };
 
 const display = async (input: string): Promise<File> => {
-  const output = RNFS.TemporaryDirectoryPath + uuid() + '.png';
-  const sized = await resize(input, output, 400, 400, 'cover');
-  console.log(`Thumbnail ${sized.width}x${sized.height} - ${sized.size} bytes`);
+  const output = RNFS.TemporaryDirectoryPath + uuid() + '.jpeg';
+  const sized = await resize(input, output, 1920, 1080, 'cover');
+  console.log(`Display ${sized.width}x${sized.height} - ${sized.size} bytes`);
   return sized;
 };
 
 const gallery = async (input: string): Promise<File> => {
-  const output = RNFS.TemporaryDirectoryPath + uuid() + '.png';
-  const sized = await resize(input, output, 1080, 720, 'contain');
-  console.log(`Thumbnail ${sized.width}x${sized.height} - ${sized.size} bytes`);
+  const output = RNFS.TemporaryDirectoryPath + uuid() + '.jpeg';
+  const sized = await resize(input, output, 2560, 1440, 'contain');
+  console.log(`Gallery ${sized.width}x${sized.height} - ${sized.size} bytes`);
   return sized;
 };
 
@@ -61,21 +61,19 @@ const resize = async (
     input,
     x,
     y,
-    'PNG',
-    100,
+    'JPEG',
+    80,
     undefined,
     output,
     undefined,
     {mode, onlyScaleDown: true},
   );
 
-  console.log(`${width}x${height} - ${size}`);
-
   return {
     width,
     height,
     path: uri,
-    mime: 'image/png',
+    mime: 'image/jpeg',
     size,
     duration: undefined,
   };

--- a/src/memories/MemoryDisplayView.tsx
+++ b/src/memories/MemoryDisplayView.tsx
@@ -44,7 +44,7 @@ const MemoryDisplayPicture = ({content}: {content: Content}) => (
   <View style={s.image}>
     <Image
       style={{width: '100%', height: '100%'}}
-      source={{uri: contentUrl(content, 'display')}}
+      source={{uri: contentUrl(content, 'thumbnail')}}
     />
   </View>
 );


### PR DESCRIPTION
## Description
- Fix Image and Video Compression
- Use JPEG instead of PNG as the compression was unreliable
- Increase the sizes of all the images/videos in general to prevent bluriness
- Use a different method for scaling the video to prevent the stretching bug
- Calculate the dimensions of videos using ffprobe instead of relying on the (incorrect) dimensions provided by react-native-image-picker

## Testing
- Manual

## Issue Resolution
- N/A

## Dependencies
- N/A

## Screenshots
- N/A